### PR TITLE
Fix: Ensure content ends with trailing newline in patch, append, and put operations

### DIFF
--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -116,6 +116,10 @@ class Obsidian():
     def append_content(self, filepath: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
         
+        # Ensure content ends with a newline to prevent subsequent sections from being appended
+        if content and not content.endswith('\n'):
+            content = content + '\n'
+        
         def call_fn():
             response = requests.post(
                 url, 
@@ -131,6 +135,10 @@ class Obsidian():
     
     def patch_content(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
+        
+        # Ensure content ends with a newline to prevent subsequent sections from being appended
+        if content and not content.endswith('\n'):
+            content = content + '\n'
         
         headers = self._get_headers() | {
             'Content-Type': 'text/markdown',
@@ -148,6 +156,10 @@ class Obsidian():
 
     def put_content(self, filepath: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
+        
+        # Ensure content ends with a newline for proper markdown formatting
+        if content and not content.endswith('\n'):
+            content = content + '\n'
         
         def call_fn():
             response = requests.put(


### PR DESCRIPTION
## Summary
- Modified `patch_content()`, `append_content()`, and `put_content()` methods to automatically add trailing newlines when missing
- This prevents subsequent sections from being incorrectly appended to patched content when agents neglect to add trailing newlines

## Problem
When MCP agents use this server to patch Obsidian markdown files, they often neglect to add trailing newlines, causing subsequent sections in the file to be appended to the patched content instead of appearing on new lines.

## Solution
Added simple checks in all three content-modifying methods to ensure content ends with a newline character if it's non-empty and doesn't already have one.

## Test plan
- [x] Tested logic for all three methods with various inputs:
  - Content without trailing newlines (adds one)
  - Content already with newlines (leaves unchanged)
  - Empty content (remains empty)
  - None values (remain None)
- [ ] Manual testing with actual Obsidian integration

🤖 Generated with [Claude Code](https://claude.ai/code)