### PR TITLE
Fix: Prevent bullet points from appearing on headers after patch operations

### DIFF
--- a/PATCH_TOOL_GUIDELINES.md
+++ b/PATCH_TOOL_GUIDELINES.md
@@ -1,0 +1,53 @@
+# Patch Tool Usage Guidelines
+
+## Known Issue: Bullet Points Appearing After Patched Sections
+
+When using the `patch_content` tool to update sections in markdown files, the following section's header may incorrectly have a bullet point prepended to it.
+
+### Example of the Issue
+Before patch:
+```markdown
+## Section 1
+Content here
+
+## Section 2
+Content here
+```
+
+After patching Section 1, Section 2 might become:
+```markdown
+## Section 1
+Updated content
+
+- ## Section 2
+Content here
+```
+
+## Solutions
+
+### 1. Double Newline Fix (Implemented)
+The patch tool now automatically adds double newlines at the end of content to ensure proper paragraph separation. This should prevent most cases of the issue.
+
+### 2. Manual Workarounds for MCP Agents
+When instructing MCP agents to use the patch tool, include these guidelines:
+
+```
+When using the patch tool:
+1. Always ensure your content ends with at least one blank line
+2. If replacing a section, include a blank line at the end
+3. For section headers, ensure there's a blank line before and after
+```
+
+### 3. Content Formatting Best Practices
+- Always separate sections with blank lines
+- Ensure headers have blank lines before and after them
+- When patching content between headers, maintain the blank line separation
+
+## Technical Details
+The issue appears to be related to how the Obsidian API interprets markdown context when content is patched. Without proper paragraph breaks (double newlines), the parser may continue list formatting from previous content into subsequent sections.
+
+## Testing Recommendations
+After patching a section:
+1. Verify the next section's header is intact
+2. Check for any unintended list markers (-, *, +)
+3. Ensure proper spacing between sections

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -136,9 +136,13 @@ class Obsidian():
     def patch_content(self, filepath: str, operation: str, target_type: str, target: str, content: str) -> Any:
         url = f"{self.get_base_url()}/vault/{filepath}"
         
-        # Ensure content ends with a newline to prevent subsequent sections from being appended
-        if content and not content.endswith('\n'):
-            content = content + '\n'
+        # Ensure content ends with double newlines to create a proper paragraph break
+        # This prevents the next section from being interpreted as a list item
+        if content and not content.endswith('\n\n'):
+            if content.endswith('\n'):
+                content = content + '\n'
+            else:
+                content = content + '\n\n'
         
         headers = self._get_headers() | {
             'Content-Type': 'text/markdown',


### PR DESCRIPTION
## Summary
- Modified `patch_content()` to add double newlines instead of single newlines  
- This prevents the Obsidian API from interpreting the next section header as a list item
- Added documentation explaining the issue and best practices for using the patch tool

## Test plan
- [ ] Apply a patch to a markdown section that has another section following it
- [ ] Verify the next section's header doesn't have a bullet point prepended
- [ ] Confirm existing patch operations continue to work correctly
- [ ] Test with various content endings (no newline, single newline, double newline)

🤖 Generated with [Claude Code](https://claude.ai/code)